### PR TITLE
Fastcgi support for nginx, removed apache stop and public domain support...

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Attributes
 * `node['munin']['server_role']` - role of the munin server. Default is monitoring.
 * `node['munin']['docroot']` - document root for the server apache vhost. on archlinux, the default is `/srv/http/munin`, or `/var/www/munin` on other platforms.
 * `node['munin']['web_server']` - supports apache or nginx, default is "apache"
+* `node['munin']['nginx_fastcgi_support']` - provides fast-cgi graphs config section for "nginx" web_server
 
 Recipes
 =======

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -1,21 +1,28 @@
 server {
   
   listen <%= @listen_port %>;
-  server_name munin <%= node[:ipaddress] -%>;
-  access_log <%= node[:nginx][:log_dir] %>/access.log;
-  error_log <%= node[:nginx][:log_dir] %>/error.log;
+  server_name munin <%= @public_domain %> <%= @fqdn %>;
+
+  access_log <%= File.join(@log_dir, 'nginx_access.log') %>;
+  error_log <%= File.join(@log_dir, 'nginx_error.log') %>;
+
+  auth_basic "Munin Server";
+  auth_basic_user_file <%= @htpasswd_file %>;
 
   location /munin {
-    root <%= File.dirname @docroot %>;
-    auth_basic "Munin Server";
-    auth_basic_user_file <%= @htpasswd_file %>;
+    root <%= @docroot %>;
   }
 
-  location /nginx_status {
-    stub_status on;
-    access_log off;
-    allow 127.0.0.1;
-    deny all;
+  <% if @nginx_fastcgi_support %>
+  location ^~ /cgi-bin/munin-cgi-graph/ {
+    fastcgi_split_path_info ^(/cgi-bin/munin-cgi-graph)(.*);
+    fastcgi_param PATH_INFO $fastcgi_path_info;
+    fastcgi_pass unix:/var/run/munin/fastcgi-graph.sock;
+    include fastcgi_params;
   }
-  
+  <% end %>
+
+  location / {
+    root <%= @docroot %>;
+  }
 }


### PR DESCRIPTION
..., should be more in line with opscode master

I also removed nginx-status section, because chef-solo is not limited to "one in all" setup, and nginx-status doesn't directly related to the munin-server in my mind since it should be available for munin-nodes data collection.

If it's "one in one box" approach - install nginx-status as part of other recipe or cookbook (site-cookbook). Seems more general.
